### PR TITLE
feat: pysodafair rename and public

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
-name = "pysoda-fairdataihub-tools"
-version = "0.1.61"
+name = "pysodafair"
+version = "0.1.62"
 description = "Pysoda package for Fairdataihub tools"
-authors = ["Your Name <cmarroquin@calmi2.org>"]
+authors = ["Christopher Marroquin <cmarroquin@calmi2.org>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/fairdataihub/pysoda"
-repository = "https://github.com/fairdataihub/pysoda"
+homepage = "https://github.com/fairdataihub/pysodafair"
+repository = "https://github.com/fairdataihub/pysodafair"
 packages = [
     { include = "pysoda" }
 ]

--- a/pysoda/core/dataset_generation/upload.py
+++ b/pysoda/core/dataset_generation/upload.py
@@ -2335,7 +2335,6 @@ def ps_upload_to_dataset(soda, ps, ds, resume=False):
         generate_option = soda["generate-dataset"]["generate-option"]
         starting_point = soda["starting-point"]["origin"]
         relative_path = ds["content"]["name"]
-
  
 
         # 1. Scan the dataset structure and create a list of files/folders to be uploaded with the desired renaming
@@ -2466,6 +2465,8 @@ def ps_upload_to_dataset(soda, ps, ds, resume=False):
                     list_upload_files,
                     relative_path,
                 )
+
+                logger.info(f"List of files to upload: {list_upload_files}")
 
 
                 # return and mark upload as completed if nothing is added to the manifest


### PR DESCRIPTION
## Summary by Sourcery

Rename the project to pysodafair with updated metadata and add an info log for upload file lists

Enhancements:
- Rename package to pysodafair and update version, authors, homepage, and repository metadata
- Add info-level logging of the list of files to upload in monitor_subscriber_progress