### PR TITLE
feat: pennsieve connect error handling

### DIFF
--- a/pysoda/core/dataset_generation/upload.py
+++ b/pysoda/core/dataset_generation/upload.py
@@ -3460,10 +3460,7 @@ def validate_dataset_structure(soda, resume):
             connect_pennsieve_client(accountname)
         except Exception as e:
             main_curate_status = "Done"
-            if isinstance(e, AttributeError):
-                raise Exception("The Pennsieve Agent cannot access datasets but needs to in order to work. Please try again. If the issue persists, please contact the SODA team. The SODA team will contact Pennsieve to help resolve this issue.")
-            else:
-                raise PennsieveAccountInvalid("Please select a valid Pennsieve account.")
+            raise e
 
     if uploading_to_existing_ps_dataset(soda):
         # check that the Pennsieve dataset is valid

--- a/pysoda/schema/dataset_description.json
+++ b/pysoda/schema/dataset_description.json
@@ -4,7 +4,8 @@
   "properties": {
     "metadata_version": {
       "type": "string",
-      "description": "The version of the metadata schema used."
+      "description": "The version of the metadata schema used.",
+      "enum": ["3.0.0", "3.0.1", "3.0.2"]
     },
     "type": {
       "type": "string",

--- a/pysoda/utils/exceptions.py
+++ b/pysoda/utils/exceptions.py
@@ -17,6 +17,14 @@ class PennsieveAgentError(Exception):
     def __str__(self):
         return self.error_message
     
+
+class PennsieveAgentRPCError(Exception):
+    def __init__(self, error_message):
+        self.error_message = error_message
+
+    def __str__(self):
+        return self.error_message
+    
 class FailedToFetchPennsieveDatasets(Exception):
     def __init__(self, error_message):
         self.error_message = error_message

--- a/pysoda/utils/exceptions.py
+++ b/pysoda/utils/exceptions.py
@@ -128,7 +128,7 @@ class PennsieveDatasetNameInvalid(Exception):
 class PennsieveAccountInvalid(Exception):
     def __init__(self, account_name):
         self.account_name = account_name
-        self.error_message = f"The Pennsieve account name {self.account_name} is invalid."
+        self.error_message = f"The Pennsieve account name {self.account_name} is invalid. Please try again. If the issue persists, please contact the SODA team."
 
     def __str__(self):
         return self.error_message

--- a/pysoda/utils/pennsieveAgentUtils.py
+++ b/pysoda/utils/pennsieveAgentUtils.py
@@ -12,7 +12,9 @@ def connect_pennsieve_client(account_name):
             raise PennsieveAgentRPCError(f"Could not connect to the Pennsieve Agent error coming from the Agent. This can likely be resolved by retrying. If the issue persists, please contact the SODA team and they will reach out to Pennsieve to help resolve this.") from e
         elif isinstance(e, AttributeError):
             raise Exception("The Pennsieve Agent cannot access datasets but needs to in order to work. Please try again. If the issue persists, please contact the SODA team. The SODA team will contact Pennsieve to help resolve this issue.") from e
-        elif "403" or "404" in str(e):
-            raise PennsieveAccountInvalid("Please select a valid Pennsieve account.") from e
+        elif "Profile not found" in str(e):
+            raise PennsieveAccountInvalid(account_name) from e
         elif "Error connecting to server" in str(e):
             raise PennsieveAgentError(f"Could not connect to the Pennsieve agent: {e}") from e
+        else:
+            raise PennsieveAgentError("An unknown error occurred when trying to connect to the Pennsieve Agent. If this issue persists, please contact the SODA team.") from e

--- a/pysoda/utils/pennsieveAgentUtils.py
+++ b/pysoda/utils/pennsieveAgentUtils.py
@@ -1,5 +1,5 @@
 from pennsieve2.pennsieve import Pennsieve
-from .exceptions import PennsieveAgentError
+from .exceptions import PennsieveAgentError, PennsieveAgentRPCError, PennsieveAccountInvalid
 
 def connect_pennsieve_client(account_name):
     """
@@ -8,4 +8,11 @@ def connect_pennsieve_client(account_name):
     try:
         return Pennsieve(profile_name=account_name)
     except Exception as e:
-        raise PennsieveAgentError(f"Could not connect to the Pennsieve agent: {e}")
+        if "End of TCP stream" in str(e):
+            raise PennsieveAgentRPCError(f"Could not connect to the Pennsieve Agent error coming from the Agent. This can likely be resolved by retrying. If the issue persists, please contact the SODA team and they will reach out to Pennsieve to help resolve this.") from e
+        elif isinstance(e, AttributeError):
+            raise Exception("The Pennsieve Agent cannot access datasets but needs to in order to work. Please try again. If the issue persists, please contact the SODA team. The SODA team will contact Pennsieve to help resolve this issue.") from e
+        elif "403" or "404" in str(e):
+            raise PennsieveAccountInvalid("Please select a valid Pennsieve account.") from e
+        elif "Error connecting to server" in str(e):
+            raise PennsieveAgentError(f"Could not connect to the Pennsieve agent: {e}") from e


### PR DESCRIPTION
## Summary by Sourcery

Improve Pennsieve agent connection error handling and messaging across utilities and dataset validation.

Bug Fixes:
- Propagate specific Pennsieve connection and account errors from the agent instead of masking them with generic exceptions.

Enhancements:
- Introduce a dedicated PennsieveAgentRPCError to distinguish agent RPC issues from other failures.
- Refine PennsieveAccountInvalid error messaging to guide users toward retrying and contacting the SODA team when problems persist.
- Centralize Pennsieve agent access and account validation error handling in connect_pennsieve_client, simplifying callers.